### PR TITLE
Check return value from InputStream.read(byte[]) is -1

### DIFF
--- a/src/main/java/com/philvarner/clamavj/ClamScan.java
+++ b/src/main/java/com/philvarner/clamavj/ClamScan.java
@@ -192,7 +192,7 @@ public class ClamScan {
 
             int read = CHUNK_SIZE;
             byte[] buffer = new byte[CHUNK_SIZE];
-            while (read == CHUNK_SIZE) {
+            while (read != -1) {
                 try {
                     read = in.read(buffer);
                 } catch (IOException e) {
@@ -200,7 +200,7 @@ public class ClamScan {
                     return new ScanResult(e);
                 }
 
-                if (read > 0) { // if previous read exhausted the stream
+                if (read != -1) { // send buffer if previous read did not exhaust the stream
                     try {
                         dos.writeInt(read);
                         dos.write(buffer, 0, read);
@@ -225,7 +225,7 @@ public class ClamScan {
                 read = 0;
             }
 
-            if (read > 0) response = new String(buffer, 0, read);
+            if (read != -1) response = new String(buffer, 0, read);
 
         } finally {
             if (dos != null) try {

--- a/src/test/java/com/philvarner/clamavj/test/ClamScanTestCase.java
+++ b/src/test/java/com/philvarner/clamavj/test/ClamScanTestCase.java
@@ -17,6 +17,7 @@ import static com.philvarner.clamavj.ScanResult.RESPONSE_OK;
 
 public class ClamScanTestCase {
 
+    private static final String EicarStandardAVTestFIle = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*";
     private ClamScan scanner;
 
     @Before
@@ -42,7 +43,7 @@ public class ClamScanTestCase {
     @Test
     public void testVirus() throws Exception {
         InputStream is = new ByteArrayInputStream(
-                "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".getBytes());
+                EicarStandardAVTestFIle.getBytes());
         assertNotNull(is);
         ScanResult result = scanner.scan(is);
         assertEquals(Status.FAILED, result.getStatus());
@@ -52,7 +53,7 @@ public class ClamScanTestCase {
 
     @Test
     public void testVirusAsByteArray() throws Exception {
-        byte[] bytes = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".getBytes();
+        byte[] bytes = EicarStandardAVTestFIle.getBytes();
         ScanResult result = scanner.scan(bytes);
         assertEquals(Status.FAILED, result.getStatus());
         assertEquals("stream: Eicar-Test-Signature FOUND", result.getResult());
@@ -84,6 +85,19 @@ public class ClamScanTestCase {
 
         }
     }
+    
+    @Test
+    public void testVirusFromSlowInputStream() throws Exception {
+        // An InputStream that does not completely fill the provided byte array for read(byte[]...)
+        InputStream is = new SlowEicarInputStream();
+        assertNotNull(is);
+        ScanResult result = scanner.scan(is);
+        assertEquals(Status.FAILED, result.getStatus());
+        assertEquals("stream: Eicar-Test-Signature FOUND", result.getResult());
+        assertEquals("Eicar-Test-Signature", result.getSignature());
+    }
+
+    
 
     @Test
     public void testNoArgConstructor() throws Exception {
@@ -92,7 +106,7 @@ public class ClamScanTestCase {
         scanner.setPort(3310);
         scanner.setTimeout(60000);
 
-        byte[] bytes = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".getBytes();
+        byte[] bytes = EicarStandardAVTestFIle.getBytes();
         ScanResult result = scanner.scan(bytes);
         assertEquals(Status.FAILED, result.getStatus());
         assertEquals("stream: Eicar-Test-Signature FOUND", result.getResult());

--- a/src/test/java/com/philvarner/clamavj/test/SlowEicarInputStream.java
+++ b/src/test/java/com/philvarner/clamavj/test/SlowEicarInputStream.java
@@ -1,0 +1,51 @@
+package com.philvarner.clamavj.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+// The purpose of this class is to provide an InputStream that does not completely 
+// fill the provided byte array for read(byte[]...).  The InputStream class guarantees at least one byte
+// is read if the stream hasn't reached the end of file.
+//
+// As the Java documentation states:
+//   If the length of b is zero, then no bytes are read and 0 is returned; 
+//   otherwise, there is an attempt to read at least one byte.  
+//     If no byte is available because the stream is at the end of the file, the value -1 is returned; 
+//     otherwise, at least one byte is read and stored into b.
+//
+// https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read(byte[])
+
+public class SlowEicarInputStream extends InputStream {
+
+    final private byte[] bytes = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*".getBytes();
+    private int pos = 0;
+
+    public int read() {
+        if (this.pos == bytes.length) {
+          return -1;
+        }
+        return bytes[this.pos++];
+    }
+
+    public int read(byte b[], int off, int len) throws IOException {
+        // Begin copied code from superclass...
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int c = read();
+        if (c == -1) {
+            return -1;
+        }
+        b[off] = (byte)c;
+        // End copied code from superclass
+
+        // Only ever return one byte
+        return 1;
+    }
+
+}


### PR DESCRIPTION
ClamScan.scan(InputStream) now checks the return value of read(byte[]) is -1 as specified by the documentation.  Previously it incorrectly assumed the buffer passed in would be consumed as much as possible when reading from the stream.  The old behaviour meant false negatives could occur.

User: pdcoxhead
Note: Thanks to TimW and NicholasH for pointing at the fix
